### PR TITLE
feat: add login session url for desktop platforms

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,6 +22,10 @@ const SideBar: DefaultTheme.Sidebar = [
         text: "Creating Custom Buttons",
         link: "/guide/creating-custom-buttons",
       },
+      {
+        text: "Using with Electron",
+        link: "/guide/using-with-electron",
+      },
     ],
   },
   {

--- a/docs/composables/use-code-client.md
+++ b/docs/composables/use-code-client.md
@@ -67,5 +67,14 @@ export interface UseCodeClientReturn {
    * @memberof UseCodeClientReturn
    */
   login: () => void | undefined;
+
+  /**
+   * Get a URL to perform code request without actually redirecting user.
+   * This is useful for platforms like _Electron/Tauri_ for redirecting user with system browser
+   *
+   * @type {Readonly<ComputedRef<string>>}
+   * @memberof UseCodeClientReturn
+   */
+  codeRequestRedirectUrl: Readonly<Ref<string | null>>;
 }
 ```

--- a/docs/guide/using-with-electron.md
+++ b/docs/guide/using-with-electron.md
@@ -1,0 +1,44 @@
+---
+title: Using with Electron
+---
+
+# Using with Electron
+
+Electron like platforms(Tauri/NW.js etc) can use an outdated version of browser/webview.
+In such cases Google would block the login attempts and warn about browser compability.
+
+To overcome this problem, you can use the System Web Browser to perform the OAuth2 login for you.
+
+> For example you might have seen this strategy with VSCode GitHub login.
+
+::: info
+We do not cover how you need to handle the response. Its based on your platform and its capabilities
+:::
+
+## Obtain a login session URL
+
+You can use [`useCodeClient`](../composables/use-code-client.md) for this. It returns `codeRequestRedirectUrl` which can be open up using system browser
+with your platform.
+
+In here we have put up an example with Electron.
+
+```ts
+const { codeRequestRedirectUrl } = useCodeClient({
+  scope,
+  // other params
+});
+
+// open this url with system browser with Electron
+mainWindow.webContents.on('new-window', function(e, url) {
+  e.preventDefault();
+  require('electron').shell.openExternal(codeRequestRedirectUrl);
+});
+
+```
+
+::: tip
+Make sure to put `redirect_url` and handle the response correctly in the system broswer. Probably you may want to run some local/remote server to exchange token.
+
+After that to open up the app from system browser can be done using a [Protocol](https://www.electronjs.org/docs/latest/api/protocol) with Electron for an example.
+
+Its also possible to send the tokens to app via a websocket channel too. It depends on your app and platform :smile:

--- a/src/utils/oauth2.ts
+++ b/src/utils/oauth2.ts
@@ -1,4 +1,4 @@
-import type { TokenResponse } from "@/interfaces/oauth2";
+import type { CodeClientConfig, TokenResponse } from "@/interfaces/oauth2";
 
 /**
  * Helper method for [google.accounts.oauth2.hasGrantedAllScopes](https://developers.google.com/identity/oauth2/web/reference/js-reference#google.accounts.oauth2.hasGrantedAllScopes)
@@ -57,4 +57,60 @@ export function revokeAccessToken(accessToken: string, done?: () => void) {
   window.google?.accounts.oauth2.revoke(accessToken, () => {
     done?.();
   });
+}
+
+export type ImplicitFlowOptions = Omit<
+  CodeClientConfig,
+  "redirect" | "callback" | "ux_mode"
+>;
+
+/**
+ * Get the OAuth2 redirect URL for login with implicit flow
+ *
+ * @export
+ * @param {ImplicitFlowOptions} options
+ * @return {string}
+ */
+export function buildCodeRequestRedirectUrl(
+  options: ImplicitFlowOptions
+): string {
+  const baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
+
+  const queryParams = new URLSearchParams({
+    gsiwebsdk: "3",
+    client_id: options.client_id,
+    scope: options.scope,
+    include_granted_scopes: "true",
+    access_type: "offline",
+    response_type: "code",
+    prompt: "consent",
+  });
+
+  if (options.hint) queryParams.append("hint", options.hint);
+  if (options.hosted_domain)
+    queryParams.append("hosted_domain", options.hosted_domain);
+  if (options.redirect_uri === undefined) {
+    queryParams.append("redirect_uri", window.origin);
+  } else {
+    queryParams.append("redirect_uri", options.redirect_uri);
+  }
+
+  if (options.select_account === undefined) {
+    queryParams.append("select_account", "false");
+  } else {
+    queryParams.append("select_account", `${options.select_account}`);
+  }
+
+  if (options.enable_serial_consent === undefined) {
+    queryParams.append("enable_serial_consent", "false");
+  } else {
+    queryParams.append(
+      "enable_serial_consent",
+      `${options.enable_serial_consent}`
+    );
+  }
+
+  if (options.state) queryParams.append("state", options.state);
+
+  return `${baseUrl}?${queryParams.toString()}`;
 }


### PR DESCRIPTION
- Allow obtaining the login session URL without doing a redirect in the browser
- Docs update

Fixes #14 

