### PR TITLE
feat: Typings for GSI client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-google-signin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-google-signin",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@rushstack/eslint-patch": "^1.1.0",

--- a/src/@types/globals.ts
+++ b/src/@types/globals.ts
@@ -1,11 +1,17 @@
-import { CodeClient } from "../interfaces/oauth2";
+import type {
+  CodeClient,
+  CodeClientConfig,
+  OverridableTokenClientConfig,
+  TokenClientConfig,
+  TokenResponse,
+} from "../interfaces/oauth2";
 
-import {
+import type {
   IdConfiguration,
   MomentListener,
   GsiButtonConfiguration,
   RevocationCallback,
-} from "@/interfaces/accounts";
+} from "../interfaces/accounts";
 
 declare global {
   interface Window {
@@ -51,3 +57,5 @@ declare global {
     };
   }
 }
+
+export default {};

--- a/src/composables/useCodeClient.ts
+++ b/src/composables/useCodeClient.ts
@@ -129,7 +129,8 @@ export default function useCodeClient(
     });
 
     client = window.google?.accounts.oauth2.initCodeClient({
-      client_id: clientId,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      client_id: clientId!,
       scope: computedScopes,
       callback: (response: CodeResponse) => {
         if (response.error) return onError?.(response);

--- a/src/composables/useTokenClient.ts
+++ b/src/composables/useTokenClient.ts
@@ -111,7 +111,8 @@ export default function useTokenClient(
       : scopeValue;
 
     client = window.google?.accounts.oauth2.initTokenClient({
-      client_id: clientId,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      client_id: clientId!,
       scope: `openid email profile ${scopes}`,
       callback: (response: TokenResponse) => {
         if (response.error) return onError?.(response);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -82,5 +82,6 @@ export type {
   AuthCodeFlowErrorResponse,
   AuthCodeFlowSuccessResponse,
 };
+export * from "./@types/globals";
 
 export default plugin;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,9 @@
       "DOM.Iterable",
       "ESNext"
     ],
+    "typeRoots": [
+      "./src/@types"
+    ],
     "strict": true,
     "removeComments": false
   },


### PR DESCRIPTION
- Typings for GSI client are now globally available when importing packages. So you can use them directly with `window.google?`